### PR TITLE
add options to set initial mu0 and r0 for optim() in cnbinom.pars()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+
+# === emacs ===
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+.org-id-locations
+*_archive
+*_flymake.*
+flycheck_*.el
+.projectile
+# === end emacs ===
+
+# === linux ===
+# Temp files from deleted-but-open handles
+.fuse_hidden*
+# KDE Dolphin file manager metadata
+.directory
+# Linux trash folder (can appear on any partition)
+.Trash-*
+# NFS stale file handles
+.nfs*
+# nohup default output
+nohup.out
+# === end linux ===
+
+# === os ===
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+*.swp
+*.swo
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+tmp/
+tmp.*
+temp/
+*.tmp
+logs/
+*.log
+# === end os ===
+
+# === r ===
+.Rhistory
+.Rapp.history
+.RData
+.Ruserdata
+*-Ex.R
+/*.tar.gz
+/*.Rcheck/
+.Rproj.user/
+vignettes/*.html
+vignettes/*.pdf
+.httr-oauth
+*_cache/
+/cache/
+*.utf8.md
+*.knit.md
+.Renviron
+Rplots.pdf
+nohup.out
+# === end r ===

--- a/R/cnbinom.pars_function.R
+++ b/R/cnbinom.pars_function.R
@@ -3,7 +3,7 @@ library(stringr)
 # cnbinom.pars is a function that outputs mu and r from univariate censored table input 
 # assume negative binomial 
 
-cnbinom.pars<-function (censoredtable){
+cnbinom.pars<-function (censoredtable, mu0 = 100, r0 = 100, warn = -1, ...){
   
   
   # make probabilities if not already
@@ -283,11 +283,12 @@ findtypeofcensoring_univariatetable<-function (univariatefreqtable){
 
   # optimize mu and r in loglikelihood_univariatecase
   # hide warnings... 
-  options(warn=-1)
+    options(warn = warn)
+    
   fixdata_univariatecase_output=fixdata_univariatecase(censoredtable)
-  op<- optim(par=c(100,100),
+  op<- optim(par=c(mu0, r0),
              fn =loglikelihood_univariatecase, 
-             fixdata_univariatecase_output=fixdata_univariatecase_output)
+             fixdata_univariatecase_output=fixdata_univariatecase_output, ...)
   final<-op$par
   mu = final[1]
   r = final[2]

--- a/README.md
+++ b/README.md
@@ -23,13 +23,16 @@ library(revengc)
 ## Usage
 `cnbinom.pars()` has the following format 
 ```
-cnbinom.pars(censoredtable)
+cnbinom.pars(censoredtable, mu0 = 100, r0 = 100, warn = -1, ...)
 ``` 
 
 where a description of the argument directly below 
 
 * **censoredtable** - A frequency table (censored and/or uncensored).  A data.frame and matrix are acceptable classes.  See Table format section below.
-
+* **mu0, r0** starting values for `mu` and `r` used by optim.
+* **warn** - Value used for `options(warn)` during `optim()` fitting. 
+  `-1` suppresses warnings
+* **...** - Additional arguments to be passed to `optim()`
 
 `rec()` has the following format where a description of each argument is found below 
  


### PR DESCRIPTION
- also add `warn` and `...` arguments

We had problems with the cnbinom.pars() function generating poor estimates due to the default starting values.  I've modified the code to allow the user to set mu0 and r0 to something other than their default values of 100.